### PR TITLE
Fix amount-two input bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
             <option value="VND">VND</option>
             <option value="ZAR">ZAR</option>
           </select>
-          <input type="number" id="amount-two" placeholder="0" />
+          <input type="number" id="amount-two" placeholder="0" readonly />
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -20,7 +20,6 @@ function calculate() {
 currencyOne.addEventListener("change", calculate);
 amountOne.addEventListener("input", calculate);
 currencyTwo.addEventListener("change", calculate);
-amountTwo.addEventListener("input", calculate);
 
 swap.addEventListener("click", () => {
   const storedValue = currencyOne.value;


### PR DESCRIPTION
## Summary
- make amount-two field read-only
- remove unused input handler for amount-two

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6868c5acea90832f9d087028c37a757a